### PR TITLE
Fix `test_cli.py` folder initialization

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,18 @@ from cli import deposit
 from eth2deposit.utils.constants import DEFAULT_VALIDATOR_KEYS_FOLDER_NAME
 
 
+def clean_key_folder(my_folder_path):
+    validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
+    if not os.path.exists(validator_keys_folder_path):
+        return
+
+    _, _, key_files = next(os.walk(validator_keys_folder_path))
+    for key_file_name in key_files:
+        os.remove(os.path.join(validator_keys_folder_path, key_file_name))
+    os.rmdir(validator_keys_folder_path)
+    os.rmdir(my_folder_path)
+
+
 def test_deposit(monkeypatch):
     # monkeypatch get_mnemonic
     def get_mnemonic(language, words_path, entropy=None):
@@ -14,8 +26,8 @@ def test_deposit(monkeypatch):
 
     monkeypatch.setattr(deposit, "get_mnemonic", get_mnemonic)
 
-    # Prepare folder
     my_folder_path = os.path.join(os.getcwd(), 'my_folder_name')
+    clean_key_folder(my_folder_path)
     if not os.path.exists(my_folder_path):
         os.mkdir(my_folder_path)
 
@@ -32,7 +44,4 @@ def test_deposit(monkeypatch):
     assert len(key_files) == 2
 
     # Clean up
-    for key_file_name in key_files:
-        os.remove(os.path.join(validator_keys_folder_path, key_file_name))
-    os.rmdir(validator_keys_folder_path)
-    os.rmdir(my_folder_path)
+    clean_key_folder(my_folder_path)


### PR DESCRIPTION
### Issue

We should clean up the testing key folder before executing `test_cli.py`.

### How did I fix it

Add a `clean_key_folder` helper. Call it before and after we run the deposit tool.