### PR TITLE
Open mnemonic file with `encoding=utf-8`

### DIFF
--- a/eth2deposit/key_handling/key_derivation/mnemonic.py
+++ b/eth2deposit/key_handling/key_derivation/mnemonic.py
@@ -14,7 +14,7 @@ from eth2deposit.utils.crypto import (
 
 
 def _get_word_list(language: str, path: str) -> Sequence[str]:
-    return open(os.path.join(path, '%s.txt' % language)).readlines()
+    return open(os.path.join(path, '%s.txt' % language), encoding='utf-8').readlines()
 
 
 def _get_word(*, word_list: Sequence[str], index: int) -> str:

--- a/tests/test_key_handling/test_key_derivation/test_mnemonic.py
+++ b/tests/test_key_handling/test_key_derivation/test_mnemonic.py
@@ -12,7 +12,7 @@ WORD_LISTS_PATH = os.path.join(os.getcwd(), 'eth2deposit', 'key_handling', 'key_
 
 test_vector_filefolder = os.path.join('tests', 'test_key_handling',
                                       'test_key_derivation', 'test_vectors', 'mnemonic.json')
-with open(test_vector_filefolder, 'r') as f:
+with open(test_vector_filefolder, 'r', encoding='utf-8') as f:
     test_vectors = json.load(f)
 
 


### PR DESCRIPTION
### Issue
It was detected by [Windows tests](https://app.circleci.com/pipelines/github/ethereum/eth2.0-deposit-cli/78/workflows/7fbe60ac-63a8-4a19-b22f-0c2562014dd0/jobs/323) that we have to set `encoding` when reading UTF8 encoded files (Chinese and Korean).

### How did I fix it
Add `encoding=utf8`.