### PR TITLE
Revert "Bump py_ecc to 4.0.0"

### DIFF
--- a/eth2deposit/credentials.py
+++ b/eth2deposit/credentials.py
@@ -28,11 +28,11 @@ class ValidatorCredentials:
 
     @property
     def signing_pk(self) -> bytes:
-        return bls.SkToPk(self.signing_sk)
+        return bls.PrivToPub(self.signing_sk)
 
     @property
     def withdrawal_pk(self) -> bytes:
-        return bls.SkToPk(self.withdrawal_sk)
+        return bls.PrivToPub(self.withdrawal_sk)
 
     @property
     def withdrawal_credentials(self) -> bytes:
@@ -73,7 +73,7 @@ def sign_deposit_data(deposit_data: DepositMessage, sk: int) -> Deposit:
     '''
     Given a DepositMessage, it signs its root and returns a Deposit
     '''
-    assert bls.SkToPk(sk) == deposit_data.pubkey
+    assert bls.PrivToPub(sk) == deposit_data.pubkey
     domain = compute_domain()
     signing_root = compute_signing_root(deposit_data, domain)
     signed_deposit_data = Deposit(

--- a/eth2deposit/key_handling/keystore.py
+++ b/eth2deposit/key_handling/keystore.py
@@ -102,7 +102,7 @@ class Keystore(BytesDataclass):
         cipher = AES_128_CTR(key=decryption_key[:16], **keystore.crypto.cipher.params)
         keystore.crypto.cipher.message = cipher.encrypt(secret)
         keystore.crypto.checksum.message = SHA256(decryption_key[16:32] + keystore.crypto.cipher.message)
-        keystore.pubkey = bls.SkToPk(int.from_bytes(secret, 'big')).hex()
+        keystore.pubkey = bls.PrivToPub(int.from_bytes(secret, 'big')).hex()
         keystore.path = path
         return keystore
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-py-ecc==4.0.0 \
-    --hash=sha256:0712a1ebc2d45417088aa613f28518c1714c99d023998e50244c91e3acbb0d6c \
-    --hash=sha256:a637edcce7e31ddefae0a3c1018f16e25c9428fcd524b1ac5ceeb2adfc433276
+py-ecc==2.0.0 \
+    --hash=sha256:0ad540e3a3df332692e35dfac8e550592c345b249d54d6d6c9a91f57bd2a75af \
+    --hash=sha256:c32cb3aa13b6d5a555f6cad629fb5d2d4af3cd607f239c3422654e1df208ed78
 pycryptodome==3.9.7 \
     --hash=sha256:07024fc364869eae8d6ac0d316e089956e6aeffe42dbdcf44fe1320d96becf7f \
     --hash=sha256:09b6d6bcc01a4eb1a2b4deeff5aa602a108ec5aed8ac75ae554f97d1d7f0a5ad \
@@ -63,6 +63,3 @@ toolz==0.10.0 \
 six==1.14.0 \
     --hash=sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a \
     --hash=sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c
-cached-property==1.5.1 \
-    --hash=sha256:3a026f1a54135677e7da5ce819b0c690f156f37976f3e30c5430740725203d7f \
-    --hash=sha256:9217a59f14a5682da7c4b8829deadbfc194ac22e9908ccf7c8820234e80a1504


### PR DESCRIPTION
Reverts ethereum/eth2.0-deposit-cli#33
Due to https://github.com/ethereum/eth2.0-deposit/milestone/1