### PR TITLE
Create uuid during calling `encrypt` instead of using class attribute

### DIFF
--- a/eth2deposit/key_handling/keystore.py
+++ b/eth2deposit/key_handling/keystore.py
@@ -65,7 +65,7 @@ class Keystore(BytesDataclass):
     crypto: KeystoreCrypto = KeystoreCrypto()
     pubkey: str = ''
     path: str = ''
-    uuid: str = str(uuid4())  # Generate a new uuid
+    uuid: str = ''
     version: int = 4
 
     def kdf(self, **kwargs: Any) -> bytes:
@@ -96,6 +96,7 @@ class Keystore(BytesDataclass):
                 kdf_salt: bytes=randbits(256).to_bytes(32, 'big'),
                 aes_iv: bytes=randbits(128).to_bytes(16, 'big')) -> 'Keystore':
         keystore = cls()
+        keystore.uuid = str(uuid4())
         keystore.crypto.kdf.params['salt'] = kdf_salt
         decryption_key = keystore.kdf(password=password, **keystore.crypto.kdf.params)
         keystore.crypto.cipher.params['iv'] = aes_iv

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 from eth2deposit import deposit
 from eth2deposit.deposit import main
 from eth2deposit.utils.constants import DEFAULT_VALIDATOR_KEYS_FOLDER_NAME
+from eth2deposit.key_handling.keystore import Keystore
 
 
 def clean_key_folder(my_folder_path):
@@ -36,7 +37,7 @@ def test_deposit(monkeypatch):
         os.mkdir(my_folder_path)
 
     runner = CliRunner()
-    inputs = ['1', 'english', 'MyPassword', 'MyPassword', 'fakephrase']
+    inputs = ['5', 'english', 'MyPassword', 'MyPassword', 'fakephrase']
     data = '\n'.join(inputs)
     result = runner.invoke(main, ['--folder', my_folder_path], input=data)
 
@@ -45,7 +46,17 @@ def test_deposit(monkeypatch):
     # Check files
     validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
     _, _, key_files = next(os.walk(validator_keys_folder_path))
-    assert len(key_files) == 2
+
+    def get_uuid(key_file):
+        keystore = Keystore.from_json(key_file)
+        return keystore.uuid
+
+    all_uuid = [
+        get_uuid(validator_keys_folder_path + '/' + key_file)
+        for key_file in key_files
+        if key_file.startswith('keystore')
+    ]
+    assert len(set(all_uuid)) == 5
 
     # Clean up
     clean_key_folder(my_folder_path)


### PR DESCRIPTION
### Issue

UUID conflicts.

After generating multiple keystores with depoist-cli command, I got the same UUID for all keystone files. (see test case `test_deposit` in `test_cli.py`)

### How did I fix it

Create `uuid` during calling `encrypt` instead of using class attribute.