### PR TITLE
Medalla chain support

### DIFF
--- a/eth2deposit/settings.py
+++ b/eth2deposit/settings.py
@@ -11,15 +11,18 @@ MainnetSetting = BaseChainSetting(GENESIS_FORK_VERSION=bytes.fromhex('00000000')
 WittiSetting = BaseChainSetting(GENESIS_FORK_VERSION=bytes.fromhex('00000113'))
 # Eth2 spec v0.12.1 testnet
 AltonaSetting = BaseChainSetting(GENESIS_FORK_VERSION=bytes.fromhex('00000121'))
-
+# Eth2 "official" public testnet (spec v0.12.2)
+MedallaSetting = BaseChainSetting(GENESIS_FORK_VERSION=bytes.fromhex('00000001'))
 
 MAINNET = 'mainnet'
 WITTI = 'witti'
 ALTONA = 'altona'
+MEDALLA = 'medalla'
 ALL_CHAINS: Dict[str, BaseChainSetting] = {
     MAINNET: MainnetSetting,
     WITTI: WittiSetting,
     ALTONA: AltonaSetting,
+    MEDALLA: MedallaSetting,
 }
 
 


### PR DESCRIPTION
Adds the [Genesis-fork-version for Medalla](https://github.com/goerli/medalla/blob/f50dc60/medalla/README.md) ahead of the "official" multiclient testnet.

This resolves #54 