### PR TITLE
Bump app version from v0.1.0 -> v0.2.0 to align with release versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ THIS IS A STUB FOR RUNNING THE APP
 
 setup(
     name="eth2deposit",
-    version='0.1.0',
+    version='0.2.0',
     py_modules=["eth2deposit"],
     packages=find_packages(exclude=('tests', 'docs')),
     python_requires=">=3.7,<4",


### PR DESCRIPTION
The next release version tag will be v0.2.0. This PR updates the app numbering to align these 2 numbers.