### PR TITLE
Add network (chain) name selection to prompt

### DIFF
--- a/eth2deposit/deposit.py
+++ b/eth2deposit/deposit.py
@@ -70,6 +70,7 @@ def check_python_version() -> None:
 )
 @click.option(
     '--chain',
+    prompt='Please choose the (mainnet or testnet) network/chain name',
     type=click.Choice(ALL_CHAINS.keys(), case_sensitive=False),
     default=MAINNET,
 )

--- a/eth2deposit/settings.py
+++ b/eth2deposit/settings.py
@@ -5,7 +5,7 @@ class BaseChainSetting(NamedTuple):
     GENESIS_FORK_VERSION: bytes
 
 
-# Eth2 Mainet setting
+# Eth2 Mainnet setting
 MainnetSetting = BaseChainSetting(GENESIS_FORK_VERSION=bytes.fromhex('00000000'))
 # Eth2 spec v0.11.3 testnet
 WittiSetting = BaseChainSetting(GENESIS_FORK_VERSION=bytes.fromhex('00000113'))

--- a/test_deposit_script.py
+++ b/test_deposit_script.py
@@ -27,6 +27,7 @@ async def main():
         run_script_cmd,
         '--num_validators', '1',
         '--mnemonic_language', 'english',
+        '--chain', 'mainnet',
         '--password', 'MyPassword',
         '--folder', my_folder_path,
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,7 +41,7 @@ def test_deposit(monkeypatch) -> None:
         os.mkdir(my_folder_path)
 
     runner = CliRunner()
-    inputs = ['5', 'english', 'MyPassword', 'MyPassword', 'fakephrase']
+    inputs = ['5', 'english', 'mainnet', 'MyPassword', 'MyPassword', 'fakephrase']
     data = '\n'.join(inputs)
     result = runner.invoke(main, ['--folder', my_folder_path], input=data)
 
@@ -87,6 +87,7 @@ async def test_script() -> None:
         run_script_cmd,
         '--num_validators', '1',
         '--mnemonic_language', 'english',
+        '--chain', 'mainnet',
         '--password', 'MyPassword',
         '--folder', my_folder_path,
     ]


### PR DESCRIPTION
### Issue
It seems many Medalla users didn't set the chain (network) name with flags. This PR sets chain/network selection to prompt requests.

### How did I fix it

Add prompt string:
```
Please choose the (mainnet or testnet) network/chain name (mainnet, witti, altona, medalla) [mainnet]
```

