### PR TITLE
Add Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Prevent your local modules and debug logs from being
+# copied onto your Docker image and possibly overwriting
+# modules installed within your image
+.git
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv/
 *.egg-info
 *.egg
 __pycache__
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.7-alpine
+
+WORKDIR /app
+
+COPY requirements.txt setup.py ./
+
+COPY eth2deposit ./eth2deposit
+
+RUN apk add --update gcc libc-dev linux-headers
+
+RUN pip3 install -r requirements.txt
+
+RUN python3 setup.py install
+
+ENTRYPOINT [ "python3", "./eth2deposit/deposit.py" ]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VENV_NAME?=venv
 VENV_ACTIVATE=. $(VENV_NAME)/bin/activate
 PYTHON=${VENV_NAME}/bin/python3.8
+DOCKER_IMAGE="ethereum/eth2.0-deposit-cli:latest"
 
 help:
 	@echo "clean - remove build and Python file artifacts"
@@ -51,3 +52,10 @@ build_linux: venv_build
 	${VENV_NAME}/bin/python -m pip install -r ./build_configs/linux/requirements.txt
 	export PYTHONHASHSEED=42; \
 	$(VENV_ACTIVATE) && pyinstaller ./build_configs/linux/build.spec
+
+build_docker:
+	@docker build --pull -t $(DOCKER_IMAGE) .
+
+run_docker:
+	@docker run -it --rm $(DOCKER_IMAGE)
+

--- a/README.md
+++ b/README.md
@@ -201,6 +201,42 @@ See [here](#arguments)
 ###### Successful message
 See [here](#successful-message)
 
+#### Option 4. Use Docker image
+
+##### Step 1. Build the docker image
+
+Run the following command to locally build the docker image:
+
+```sh
+make build_docker
+```
+
+##### Step 2. Create keys and `deposit_data-*.json`
+
+Run the following command to enter the interactive CLI:
+
+```sh
+docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ethereum/eth2.0-deposit-cli
+```
+
+You can also run the tool with optional arguments:
+
+```sh
+docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ethereum/eth2.0-deposit-cli --num_validators=<NUM_VALIDATORS> --mnemonic_language=english --folder=<YOUR_FOLDER_PATH>
+```
+
+Example for 1 validator on the [Medalla testnet](https://medalla.launchpad.ethereum.org/) using english:
+
+```sh
+docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ethereum/eth2.0-deposit-cli --num_validators=1 --mnemonic_language=english --chain=medalla
+```
+
+###### Arguments
+See [here](#arguments)
+
+###### Successful message
+See [here](#successful-message)
+
 ----
 
 ### For Windows users


### PR DESCRIPTION
Adds a working `Dockerfile` to generate a ready to use Docker image.

Ideally you would have a CI job that does build the image and push automatically on success. If interested I could send another PR doing just that using GitHub actions / CircleCI.