### PR TITLE
deposit.sh: Check for linux* OSTYPE instead of linux-gnu*

### DIFF
--- a/deposit.sh
+++ b/deposit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ "$OSTYPE" == "linux-gnu"* ]] || [[ "$OSTYPE" == "darwin"* ]]; then
+if [[ "$OSTYPE" == "linux"* ]] || [[ "$OSTYPE" == "darwin"* ]]; then
     echo $OSTYPE
     if [[ $1 == "install" ]]; then
         echo "Installing dependencies..."


### PR DESCRIPTION
Some Linux distributions (i.e. openSUSE) define the OSTYPE environment
variable as "linux" instead of "linux-gnu".

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>