### PR TITLE
Verifies deposit_data.json amounts ∈ [1, 32] ETH

### DIFF
--- a/eth2deposit/credentials.py
+++ b/eth2deposit/credentials.py
@@ -4,6 +4,7 @@ import json
 from typing import Dict, List
 from py_ecc.bls import G2ProofOfPossession as bls
 
+from eth2deposit.exceptions import ValidationError
 from eth2deposit.key_handling.key_derivation.path import mnemonic_and_path_to_key
 from eth2deposit.key_handling.keystore import (
     Keystore,
@@ -11,6 +12,8 @@ from eth2deposit.key_handling.keystore import (
 )
 from eth2deposit.utils.constants import (
     BLS_WITHDRAWAL_PREFIX,
+    ETH2GWEI,
+    MAX_DEPOSIT_AMOUNT,
 )
 from eth2deposit.utils.crypto import SHA256
 from eth2deposit.utils.ssz import (
@@ -57,6 +60,8 @@ class Credential:
 
     @property
     def deposit_message(self) -> DepositMessage:
+        if self.amount > MAX_DEPOSIT_AMOUNT:
+            raise ValidationError(f"{self.amount / ETH2GWEI} ETH is more than the maximum allowed deposit.")
         return DepositMessage(
             pubkey=self.signing_pk,
             withdrawal_credentials=self.withdrawal_credentials,

--- a/eth2deposit/credentials.py
+++ b/eth2deposit/credentials.py
@@ -62,7 +62,7 @@ class Credential:
     @property
     def deposit_message(self) -> DepositMessage:
         if not MIN_DEPOSIT_AMOUNT <= self.amount <= MAX_DEPOSIT_AMOUNT:
-            raise ValidationError(f"{self.amount / ETH2GWEI} ETH deposits are not within the expected bounds of this cli.")
+            raise ValidationError(f"{self.amount / ETH2GWEI} ETH deposits are not within the bounds of this cli.")
         return DepositMessage(
             pubkey=self.signing_pk,
             withdrawal_credentials=self.withdrawal_credentials,

--- a/eth2deposit/credentials.py
+++ b/eth2deposit/credentials.py
@@ -61,8 +61,8 @@ class Credential:
 
     @property
     def deposit_message(self) -> DepositMessage:
-        if MIN_DEPOSIT_AMOUNT > self.amount > MAX_DEPOSIT_AMOUNT:
-            raise ValidationError(f"{self.amount / ETH2GWEI} ETH is not within the bounds of the deposit-cli.")
+        if not MIN_DEPOSIT_AMOUNT <= self.amount <= MAX_DEPOSIT_AMOUNT:
+            raise ValidationError(f"{self.amount / ETH2GWEI} ETH deposits are not within the expected bounds of this cli.")
         return DepositMessage(
             pubkey=self.signing_pk,
             withdrawal_credentials=self.withdrawal_credentials,

--- a/eth2deposit/credentials.py
+++ b/eth2deposit/credentials.py
@@ -14,6 +14,7 @@ from eth2deposit.utils.constants import (
     BLS_WITHDRAWAL_PREFIX,
     ETH2GWEI,
     MAX_DEPOSIT_AMOUNT,
+    MIN_DEPOSIT_AMOUNT,
 )
 from eth2deposit.utils.crypto import SHA256
 from eth2deposit.utils.ssz import (
@@ -60,8 +61,8 @@ class Credential:
 
     @property
     def deposit_message(self) -> DepositMessage:
-        if self.amount > MAX_DEPOSIT_AMOUNT:
-            raise ValidationError(f"{self.amount / ETH2GWEI} ETH is more than the maximum allowed deposit.")
+        if MIN_DEPOSIT_AMOUNT > self.amount > MAX_DEPOSIT_AMOUNT:
+            raise ValidationError(f"{self.amount / ETH2GWEI} ETH is not within the bounds of the deposit-cli.")
         return DepositMessage(
             pubkey=self.signing_pk,
             withdrawal_credentials=self.withdrawal_credentials,

--- a/eth2deposit/utils/constants.py
+++ b/eth2deposit/utils/constants.py
@@ -7,8 +7,9 @@ ZERO_BYTES32 = b'\x00' * 32
 DOMAIN_DEPOSIT = bytes.fromhex('03000000')
 BLS_WITHDRAWAL_PREFIX = bytes.fromhex('00')
 
-MIN_DEPOSIT_AMOUNT = 2 ** 0 * 10 ** 9
-MAX_DEPOSIT_AMOUNT = 2 ** 5 * 10 ** 9
+ETH2GWEI = 10 ** 9
+MIN_DEPOSIT_AMOUNT = 2 ** 0 * ETH2GWEI
+MAX_DEPOSIT_AMOUNT = 2 ** 5 * ETH2GWEI
 
 
 # File/folder constants


### PR DESCRIPTION
#100 points out that large numbers may be encoded differently in different JSON parsers. This PR verifies that the `amount` field of `deposit_data.json` is within the deposit bounds (which are much tighter than the defined JSON int bounds).