### PR TITLE
[WIP] Add password length validation

### DIFF
--- a/eth2deposit/utils/validation.py
+++ b/eth2deposit/utils/validation.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 
 from py_ecc.bls import G2ProofOfPossession as bls
 
+from eth2deposit.exceptions import ValidationError
 from eth2deposit.utils.ssz import (
     compute_deposit_domain,
     compute_signing_root,
@@ -60,3 +61,8 @@ def validate_deposit(deposit_data_dict: Dict[str, Any]) -> bool:
         signature=signature,
     )
     return signed_deposit.hash_tree_root == deposit_message_root
+
+
+def validate_password_strength(password: str) -> None:
+    if len(password) < 8:
+        raise ValidationError(f"The password length should be at least 8. Got {len(password)}.")

--- a/test_deposit_script.py
+++ b/test_deposit_script.py
@@ -28,7 +28,6 @@ async def main():
         '--num_validators', '1',
         '--mnemonic_language', 'english',
         '--chain', 'mainnet',
-        '--password', 'MyPassword',
         '--folder', my_folder_path,
     ]
     print('[INFO] Creating subprocess 2: deposit-cli')
@@ -39,19 +38,23 @@ async def main():
         stderr=asyncio.subprocess.PIPE,
     )
     seed_phrase = ''
-    parsing = False
+    parsing_mnemonic = False
+    stub_password = '12345678'
     async for out in proc.stdout:
         output = out.decode('utf-8').rstrip()
-        if output.startswith("This is your seed phrase."):
-            parsing = True
+        if output.startswith("Type the password") or output.startswith("Repeat for confirmation"):
+            proc.stdin.write(stub_password.encode())
+            proc.stdin.write(b'\n')
+        elif output.startswith("This is your seed phrase."):
+            parsing_mnemonic = True
         elif output.startswith("Please type your mnemonic"):
-            parsing = False
-        elif parsing:
-            seed_phrase += output
+            parsing_mnemonic = False
             if len(seed_phrase) > 0:
                 encoded_phrase = seed_phrase.encode()
                 proc.stdin.write(encoded_phrase)
                 proc.stdin.write(b'\n')
+        elif parsing_mnemonic:
+            seed_phrase += output
         print(output)
 
     async for out in proc.stderr:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,7 +88,6 @@ async def test_script() -> None:
         '--num_validators', '1',
         '--mnemonic_language', 'english',
         '--chain', 'mainnet',
-        '--password', 'MyPassword',
         '--folder', my_folder_path,
     ]
     proc = await asyncio.create_subprocess_shell(
@@ -98,25 +97,29 @@ async def test_script() -> None:
     )
 
     seed_phrase = ''
-    parsing = False
+    parsing_mnemonic = False
+    stub_password = '12345678'
     async for out in proc.stdout:
         output = out.decode('utf-8').rstrip()
-        if output.startswith("This is your seed phrase."):
-            parsing = True
+        if output.startswith("Type the password") or output.startswith("Repeat for confirmation"):
+            proc.stdin.write(stub_password.encode())
+            proc.stdin.write(b'\n')
+        elif output.startswith("This is your seed phrase."):
+            parsing_mnemonic = True
         elif output.startswith("Please type your mnemonic"):
-            parsing = False
-        elif parsing:
-            seed_phrase += output
+            parsing_mnemonic = False
             if len(seed_phrase) > 0:
                 encoded_phrase = seed_phrase.encode()
                 proc.stdin.write(encoded_phrase)
                 proc.stdin.write(b'\n')
+        elif parsing_mnemonic:
+            seed_phrase += output
 
     assert len(seed_phrase) > 0
 
     # Check files
     validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
-    _, _, key_files = next(os.walk(validator_keys_folder_path))
+    _, _, _ = next(os.walk(validator_keys_folder_path))
 
     # Clean up
     clean_key_folder(my_folder_path)

--- a/tests/test_utils/test_validation.py
+++ b/tests/test_utils/test_validation.py
@@ -1,0 +1,19 @@
+import pytest
+
+from eth2deposit.exceptions import ValidationError
+from eth2deposit.utils.validation import validate_password_strength
+
+
+@pytest.mark.parametrize(
+    'password, valid',
+    [
+        ('12345678', True),
+        ('1234567', False),
+    ]
+)
+def test_validate_password_strength(password, valid):
+    if valid:
+        validate_password_strength(password=password)
+    else:
+        with pytest.raises(ValidationError):
+            validate_password_strength(password=password)


### PR DESCRIPTION
### Issue
Address #99

### TODO
- [ ] Fix test script: this PR removes `password` from CLI arguments. However, the current `test_deposit_script.py` doesn't handle the `hide_input=True` mode properly.
    - The CI tests could have passed with `hide_input=False` mode.
    - For `hide_input=True` mode: [`click` uses `getpass`](https://github.com/pallets/click/blob/fcbaee661309502e70ab617fe867419d3c921e17/src/click/termui.py#L49-L52) to implement the `hide_input=True` mode prompt without passing specific `stream`. It seems our asyncio `stdin` PIPE does'nt handle it well. Need to figure out how to fix the E2E test. 😢 
- [ ] Clean up the PR
