### PR TITLE
Add `deposit_cli_version` to the deposit_data*.json file

### DIFF
--- a/eth2deposit/credentials.py
+++ b/eth2deposit/credentials.py
@@ -10,6 +10,7 @@ from eth2deposit.key_handling.keystore import (
     Keystore,
     ScryptKeystore,
 )
+from eth2deposit.settings import DEPOSIT_CLI_VERSION
 from eth2deposit.utils.constants import (
     BLS_WITHDRAWAL_PREFIX,
     ETH2GWEI,
@@ -90,6 +91,7 @@ class Credential:
         datum_dict.update({'deposit_message_root': self.deposit_message.hash_tree_root})
         datum_dict.update({'deposit_data_root': signed_deposit_datum.hash_tree_root})
         datum_dict.update({'fork_version': self.fork_version})
+        datum_dict.update({'deposit_cli_version': DEPOSIT_CLI_VERSION})
         return datum_dict
 
     def signing_keystore(self, password: str) -> Keystore:

--- a/eth2deposit/settings.py
+++ b/eth2deposit/settings.py
@@ -1,7 +1,8 @@
 from typing import Dict, NamedTuple
+import pkg_resources
 
 
-DEPOSIT_CLI_VERSION = "0.4.0"
+DEPOSIT_CLI_VERSION = pkg_resources.require("eth2deposit")[0].version
 
 
 class BaseChainSetting(NamedTuple):

--- a/eth2deposit/settings.py
+++ b/eth2deposit/settings.py
@@ -1,6 +1,9 @@
 from typing import Dict, NamedTuple
 
 
+DEPOSIT_CLI_VERSION = "0.4.0"
+
+
 class BaseChainSetting(NamedTuple):
     GENESIS_FORK_VERSION: bytes
 


### PR DESCRIPTION
### Issue
When there is a breaking change (e.g., `KeyGen` updates), we want to ensure that the users are using the correct `deposit-cli` version for the given network.

### How to fix it

Discussed with @CarlBeek previously, we can check if `deposit_cli_version >= a certain version` on the launchpad to ensure that the user should have used the correct version.

There is some tool we can use the compare versions on the launchpad, e.g., [compare-versions
](https://www.npmjs.com/package/compare-versions)

#### Cons
I already set `DEPOSIT_CLI_VERSION` to the next release version. It added a task to the release process SOP: update the `DEPOSIT_CLI_VERSION` to the expected release version.

