### PR TITLE
Adds version-string updating functionality to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,8 @@ build_macos: venv_build
 build_linux: venv_build
 	${VENV_NAME}/bin/python -m pip install -r ./build_configs/linux/requirements.txt
 	$(VENV_ACTIVATE) && pyinstaller ./build_configs/linux/build.spec
+
+update_version_number:
+	@read -p "Enter new version number: " VERSION; \
+	perl -pi -e "s/(version=)\S*/\1\'$${VERSION}\',/" setup.py; \
+	perl -pi -e "s/(DEPOSIT_CLI_VERSION = )\S*/\1\"$${VERSION}\"/" eth2deposit/settings.py

--- a/eth2deposit/settings.py
+++ b/eth2deposit/settings.py
@@ -1,7 +1,7 @@
 from typing import Dict, NamedTuple
 
 
-DEPOSIT_CLI_VERSION = "0.4.0"
+DEPOSIT_CLI_VERSION = "0.3.0"
 
 
 class BaseChainSetting(NamedTuple):


### PR DESCRIPTION
Mitigates the the con @hwwhww listed in #126 by having a make option for updating the version strings.

Side note: for once, the regex was easy, but it was the BSD (and therefore OSX)/Linux differences in `sed` that forced me to switch to perl (which has broken regex syntax for capturing groups) that got me.