### PR TITLE
HOTFIX: Hardcode version number for binary builds

### DIFF
--- a/eth2deposit/settings.py
+++ b/eth2deposit/settings.py
@@ -1,8 +1,7 @@
 from typing import Dict, NamedTuple
-import pkg_resources
 
 
-DEPOSIT_CLI_VERSION = pkg_resources.require("eth2deposit")[0].version
+DEPOSIT_CLI_VERSION = "0.4.0"
 
 
 class BaseChainSetting(NamedTuple):


### PR DESCRIPTION
Binary builds broken due to not having a version of themselves in setup tools. Solution: hardcode version number

``` text
~/Downloads/eth2deposit-cli-7f43610-darwin-amd64
➜ ./deposit --num_validators 1 --chain zinken

Traceback (most recent call last):
  File "eth2deposit/deposit.py", line 5, in <module>
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "/usr/local/lib/python3.7/site-packages/PyInstaller/loader/pyimod03_importers.py", line 623, in exec_module
  File "eth2deposit/credentials.py", line 13, in <module>
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "/usr/local/lib/python3.7/site-packages/PyInstaller/loader/pyimod03_importers.py", line 623, in exec_module
  File "eth2deposit/settings.py", line 5, in <module>
  File "pkg_resources/__init__.py", line 899, in require
  File "pkg_resources/__init__.py", line 785, in resolve
pkg_resources.DistributionNotFound: The 'eth2deposit' distribution was not found and is required by the application
[89842] Failed to execute script deposit
```