### PR TITLE
Bump version number for hotfix release

### DIFF
--- a/eth2deposit/settings.py
+++ b/eth2deposit/settings.py
@@ -1,7 +1,7 @@
 from typing import Dict, NamedTuple
 
 
-DEPOSIT_CLI_VERSION = "0.4.0"
+DEPOSIT_CLI_VERSION = "0.4.1"
 
 
 class BaseChainSetting(NamedTuple):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ THIS IS A STUB FOR RUNNING THE APP
 
 setup(
     name="eth2deposit",
-    version='0.4.0',
+    version='0.4.1',
     py_modules=["eth2deposit"],
     packages=find_packages(exclude=('tests', 'docs')),
     python_requires=">=3.7,<4",


### PR DESCRIPTION
Bump version number so latest version with hotfix appears at the top of GH releases.
![Screenshot 2020-10-01 at 3 52 11 PM](https://user-images.githubusercontent.com/12530043/94818165-15f6bb80-03fe-11eb-95b5-eef07411674a.png)
