### PR TITLE
Binary checksums

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
             tar -zcvf ${BUILD_FILE_NAME}.tar.gz ./${BUILD_FILE_NAME};
             mkdir /tmp/artifacts;
             cp ${BUILD_FILE_NAME}.tar.gz /tmp/artifacts;
-            sha256sum ${BUILD_FILE_NAME}.tar.gz > /tmp/artifacts/checksum.txt
+            shasum -a 256 ${BUILD_FILE_NAME}.tar.gz > /tmp/artifacts/checksum.txt
       - store_artifacts:
           path: /tmp/artifacts
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
             Compress-Archive -Path $BUILD_FILE_NAME_PATH -DestinationPath $ZIP_FILE_NAME
             mkdir \tmp\artifacts
             copy $ZIP_FILE_NAME \tmp\artifacts\
-            certUtil -hashfile $ZIP_FILE_NAME > \tmp\artifacts\checksum.txt
+            certUtil -hashfile $ZIP_FILE_NAME > \tmp\artifacts\checksum.txt SHA256
       - store_artifacts:
           path: /tmp/artifacts
   build-macos:
@@ -192,7 +192,7 @@ jobs:
             tar -zcvf ${BUILD_FILE_NAME}.tar.gz ./${BUILD_FILE_NAME};
             mkdir /tmp/artifacts;
             cp ${BUILD_FILE_NAME}.tar.gz /tmp/artifacts;
-            esha256sum ${BUILD_FILE_NAME}.tar.gz > /tmp/artifacts/checksum.txt
+            sha256sum ${BUILD_FILE_NAME}.tar.gz > /tmp/artifacts/checksum.txt
       - store_artifacts:
           path: /tmp/artifacts
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,7 @@ jobs:
       - run:
           name: Build with build.spec
           command: |
+            export PYTHONHASHSEED=42
             export CIRCLE_SHORT_SHA1=$(eval echo $CIRCLE_SHA1 | cut -c -7)
             export BUILD_FILE_NAME=eth2deposit-cli-${CIRCLE_SHORT_SHA1}-linux-amd64;
             mkdir ${BUILD_FILE_NAME};
@@ -130,6 +131,7 @@ jobs:
             tar -zcvf ${BUILD_FILE_NAME}.tar.gz ./${BUILD_FILE_NAME};
             mkdir /tmp/artifacts;
             cp ${BUILD_FILE_NAME}.tar.gz /tmp/artifacts;
+            sha256sum ${BUILD_FILE_NAME}.tar.gz > /tmp/artifacts/checksum.txt
       - store_artifacts:
           path: /tmp/artifacts
   build-windows:
@@ -144,6 +146,7 @@ jobs:
       - run:
           name: Build with build.spec
           command: |
+            $PYTHONHASHSEED = 42
             $CIRCLE_SHORT_SHA1 = $env:CIRCLE_SHA1.substring(0,7)
             $BUILD_FILE_NAME = "eth2deposit-cli-" + $CIRCLE_SHORT_SHA1 + "-windows-amd64"
             mkdir $BUILD_FILE_NAME
@@ -159,6 +162,7 @@ jobs:
             Compress-Archive -Path $BUILD_FILE_NAME_PATH -DestinationPath $ZIP_FILE_NAME
             mkdir \tmp\artifacts
             copy $ZIP_FILE_NAME \tmp\artifacts\
+            certUtil -hashfile $ZIP_FILE_NAME > \tmp\artifacts\checksum.txt
       - store_artifacts:
           path: /tmp/artifacts
   build-macos:
@@ -175,6 +179,7 @@ jobs:
       - run:
           name: Build with build.spec
           command: |
+            export PYTHONHASHSEED=42
             export CIRCLE_SHORT_SHA1=$(eval echo $CIRCLE_SHA1 | cut -c -7)
             export BUILD_FILE_NAME=eth2deposit-cli-${CIRCLE_SHORT_SHA1}-darwin-amd64;
             mkdir ${BUILD_FILE_NAME};
@@ -187,6 +192,7 @@ jobs:
             tar -zcvf ${BUILD_FILE_NAME}.tar.gz ./${BUILD_FILE_NAME};
             mkdir /tmp/artifacts;
             cp ${BUILD_FILE_NAME}.tar.gz /tmp/artifacts;
+            esha256sum ${BUILD_FILE_NAME}.tar.gz > /tmp/artifacts/checksum.txt
       - store_artifacts:
           path: /tmp/artifacts
 

--- a/Makefile
+++ b/Makefile
@@ -29,29 +29,25 @@ $(VENV_NAME)/bin/activate: requirements.txt
 	@touch $(VENV_NAME)/bin/activate
 
 venv_build: $(VENV_NAME)/bin/activate
-	export PYTHONHASHSEED=42
 
 venv_build_test: venv_build
 	${VENV_NAME}/bin/python -m pip install -r requirements_test.txt
 
 venv_test: venv_build_test
 	$(VENV_ACTIVATE) && python -m pytest .
-	export -n PYTHONHASHSEED
 
 venv_lint: venv_build_test
 	$(VENV_ACTIVATE) && flake8 --config=flake8.ini ./eth2deposit ./tests && mypy --config-file mypy.ini -p eth2deposit
-	export -n PYTHONHASHSEED
 
 venv_deposit: venv_build
 	$(VENV_ACTIVATE) && python ./eth2deposit/deposit.py
-	export -n PYTHONHASHSEED
 
 build_macos: venv_build
 	${VENV_NAME}/bin/python -m pip install -r ./build_configs/macos/requirements.txt
-	$(VENV_ACTIVATE) && pyinstaller ./build_configs/macos/build.spec
-	export -n PYTHONHASHSEED
+	export PYTHONHASHSEED=42; \
+	$(VENV_ACTIVATE) && pyinstaller ./build_configs/macos/build.spec;
 
 build_linux: venv_build
 	${VENV_NAME}/bin/python -m pip install -r ./build_configs/linux/requirements.txt
+	export PYTHONHASHSEED=42; \
 	$(VENV_ACTIVATE) && pyinstaller ./build_configs/linux/build.spec
-	export -n PYTHONHASHSEED

--- a/Makefile
+++ b/Makefile
@@ -28,24 +28,31 @@ $(VENV_NAME)/bin/activate: requirements.txt
 	${VENV_NAME}/bin/python -m pip install -r requirements_test.txt
 	@touch $(VENV_NAME)/bin/activate
 
-venv_build: $(VENV_NAME)/bin/activate
+venv_build:
+	$(VENV_ACTIVATE)
+	export PYTHONHASHSEED=42
 
 venv_build_test: venv_build
 	${VENV_NAME}/bin/python -m pip install -r requirements_test.txt
 
 venv_test: venv_build_test
 	$(VENV_ACTIVATE) && python -m pytest .
+	export -n PYTHONHASHSEED
 
 venv_lint: venv_build_test
 	$(VENV_ACTIVATE) && flake8 --config=flake8.ini ./eth2deposit ./tests && mypy --config-file mypy.ini -p eth2deposit
+	export -n PYTHONHASHSEED
 
 venv_deposit: venv_build
 	$(VENV_ACTIVATE) && python ./eth2deposit/deposit.py
+	export -n PYTHONHASHSEED
 
 build_macos: venv_build
 	${VENV_NAME}/bin/python -m pip install -r ./build_configs/macos/requirements.txt
 	$(VENV_ACTIVATE) && pyinstaller ./build_configs/macos/build.spec
+	export -n PYTHONHASHSEED
 
 build_linux: venv_build
 	${VENV_NAME}/bin/python -m pip install -r ./build_configs/linux/requirements.txt
 	$(VENV_ACTIVATE) && pyinstaller ./build_configs/linux/build.spec
+	export -n PYTHONHASHSEED

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ $(VENV_NAME)/bin/activate: requirements.txt
 	@touch $(VENV_NAME)/bin/activate
 
 venv_build:
-	$(VENV_ACTIVATE)
+	$(VENV_NAME)/bin/activate
 	export PYTHONHASHSEED=42
 
 venv_build_test: venv_build

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,7 @@ $(VENV_NAME)/bin/activate: requirements.txt
 	${VENV_NAME}/bin/python -m pip install -r requirements_test.txt
 	@touch $(VENV_NAME)/bin/activate
 
-venv_build:
-	$(VENV_NAME)/bin/activate
+venv_build: $(VENV_NAME)/bin/activate
 	export PYTHONHASHSEED=42
 
 venv_build_test: venv_build


### PR DESCRIPTION
In order to offer signatures and checksums, this PR makes python builds deterministic and adds sha256 hashes to circle ci.