### PR TITLE
Clean checksum output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
             tar -zcvf ${BUILD_FILE_NAME}.tar.gz ./${BUILD_FILE_NAME};
             mkdir /tmp/artifacts;
             cp ${BUILD_FILE_NAME}.tar.gz /tmp/artifacts;
-            sha256sum ${BUILD_FILE_NAME}.tar.gz > /tmp/artifacts/checksum.txt
+            sha256sum ${BUILD_FILE_NAME}.tar.gz | head -c 64 > /tmp/artifacts/${BUILD_FILE_NAME}.sha256
       - store_artifacts:
           path: /tmp/artifacts
   build-windows:
@@ -162,7 +162,8 @@ jobs:
             Compress-Archive -Path $BUILD_FILE_NAME_PATH -DestinationPath $ZIP_FILE_NAME
             mkdir \tmp\artifacts
             copy $ZIP_FILE_NAME \tmp\artifacts\
-            certUtil -hashfile $ZIP_FILE_NAME > \tmp\artifacts\checksum.txt SHA256
+            $CHECKSUM_FILE_NAME_PASH = "\tmp\artifacts\"  + $BUILD_FILE_NAME + ".sha256"
+            certUtil -hashfile $ZIP_FILE_NAME SHA256 | findstr /i /v "SHA256" | findstr /i /v "CertUtil" > $CHECKSUM_FILE_NAME_PASH
       - store_artifacts:
           path: /tmp/artifacts
   build-macos:
@@ -192,7 +193,7 @@ jobs:
             tar -zcvf ${BUILD_FILE_NAME}.tar.gz ./${BUILD_FILE_NAME};
             mkdir /tmp/artifacts;
             cp ${BUILD_FILE_NAME}.tar.gz /tmp/artifacts;
-            shasum -a 256 ${BUILD_FILE_NAME}.tar.gz > /tmp/artifacts/checksum.txt
+            shasum -a 256 ${BUILD_FILE_NAME}.tar.gz | head -c 64 > /tmp/artifacts/${BUILD_FILE_NAME}.sha256
       - store_artifacts:
           path: /tmp/artifacts
 


### PR DESCRIPTION
#133 patch
Output `${BUILD_FILE_NAME}.sha256` txt file that contains only the hash string.

e.g.,
```
tmp/artifacts/eth2deposit-cli-256828b-windows-amd64.sha256
tmp/artifacts/eth2deposit-cli-256828b-windows-amd64.zip
```