### PR TITLE
Proposed tweak to from_json and from_file

### DIFF
--- a/eth2deposit/credentials.py
+++ b/eth2deposit/credentials.py
@@ -107,7 +107,7 @@ class Credential:
         return filefolder
 
     def verify_keystore(self, keystore_filefolder: str, password: str) -> bool:
-        saved_keystore = Keystore.from_json(keystore_filefolder)
+        saved_keystore = Keystore.from_file(keystore_filefolder)
         secret_bytes = saved_keystore.decrypt(password)
         return self.signing_sk == int.from_bytes(secret_bytes, 'big')
 

--- a/eth2deposit/key_handling/keystore.py
+++ b/eth2deposit/key_handling/keystore.py
@@ -98,8 +98,7 @@ class Keystore(BytesDataclass):
             f.write(self.as_json())
 
     @classmethod
-    def from_json(cls, json_dict: Dict[Any, Any]) -> 'Keystore':
-
+    def from_json(cls, json_dict: Dict[Any, Any], path='': str) -> 'Keystore':
         crypto = KeystoreCrypto.from_json(json_dict['crypto'])
         path = json_dict['path']
         uuid = json_dict['uuid']
@@ -111,7 +110,7 @@ class Keystore(BytesDataclass):
     @classmethod
     def from_file(cls, path: str) -> 'KeyStore':
         with open(path, 'r') as f:
-            return cls.from_json(json.load(f))
+            return cls.from_json(json.load(f), path)
 
     @staticmethod
     def _process_password(password: str) -> bytes:

--- a/eth2deposit/key_handling/keystore.py
+++ b/eth2deposit/key_handling/keystore.py
@@ -98,9 +98,8 @@ class Keystore(BytesDataclass):
             f.write(self.as_json())
 
     @classmethod
-    def from_json(cls, path: str) -> 'Keystore':
-        with open(path, 'r') as f:
-            json_dict = json.load(f)
+    def from_json(cls, json_dict: Dict[Any, Any]) -> 'Keystore':
+
         crypto = KeystoreCrypto.from_json(json_dict['crypto'])
         path = json_dict['path']
         uuid = json_dict['uuid']
@@ -108,6 +107,11 @@ class Keystore(BytesDataclass):
         description = json_dict.get('description', '')
         pubkey = json_dict.get('pubkey', '')
         return cls(crypto=crypto, description=description, pubkey=pubkey, path=path, uuid=uuid, version=version)
+    
+    @classmethod
+    def from_file(cls, path: str) -> 'KeyStore':
+        with open(path, 'r') as f:
+            return cls.from_json(json.load(f))
 
     @staticmethod
     def _process_password(password: str) -> bytes:

--- a/eth2deposit/key_handling/keystore.py
+++ b/eth2deposit/key_handling/keystore.py
@@ -98,7 +98,7 @@ class Keystore(BytesDataclass):
             f.write(self.as_json())
 
     @classmethod
-    def from_json(cls, json_dict: Dict[Any, Any], path='': str) -> 'Keystore':
+    def from_json(cls, json_dict: Dict[Any, Any]) -> 'Keystore':
         crypto = KeystoreCrypto.from_json(json_dict['crypto'])
         path = json_dict['path']
         uuid = json_dict['uuid']
@@ -106,11 +106,11 @@ class Keystore(BytesDataclass):
         description = json_dict.get('description', '')
         pubkey = json_dict.get('pubkey', '')
         return cls(crypto=crypto, description=description, pubkey=pubkey, path=path, uuid=uuid, version=version)
-    
+
     @classmethod
-    def from_file(cls, path: str) -> 'KeyStore':
+    def from_file(cls, path: str) -> 'Keystore':
         with open(path, 'r') as f:
-            return cls.from_json(json.load(f), path)
+            return cls.from_json(json.load(f))
 
     @staticmethod
     def _process_password(password: str) -> bytes:

--- a/tests/test_cli/helpers.py
+++ b/tests/test_cli/helpers.py
@@ -17,5 +17,5 @@ def clean_key_folder(my_folder_path: str) -> None:
 
 
 def get_uuid(key_file: str) -> str:
-    keystore = Keystore.from_json(key_file)
+    keystore = Keystore.from_file(key_file)
     return keystore.uuid

--- a/tests/test_key_handling/test_keystore.py
+++ b/tests/test_key_handling/test_keystore.py
@@ -13,7 +13,7 @@ test_vector_secret = bytes.fromhex('000000000019d6689c085ae165831e934ff763ae46a2
 test_vector_folder = os.path.join(os.getcwd(), 'tests', 'test_key_handling', 'keystore_test_vectors')
 _, _, test_vector_files = next(os.walk(test_vector_folder))  # type: ignore
 
-test_vector_keystores = [Keystore.from_json(os.path.join(test_vector_folder, f)) for f in test_vector_files]
+test_vector_keystores = [Keystore.from_file(os.path.join(test_vector_folder, f)) for f in test_vector_files]
 
 
 def test_json_serialization() -> None:


### PR DESCRIPTION
This feels to me like it would be more intuitive behavior; the `from_json` behaves the same way for Keystore and KeystoreCrypto, and it exposes a way for people to use the library with json that is not saved in a file anywhere.