### PR TITLE
chmod keystores and deposit_data.json to `440`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ You can find the audit report by Trail of Bits [here](https://github.com/trailof
 
 ### For Linux or MacOS users
 
+#### File Permissions
+
+On Unix-based systems, keystores and the `deposit_data*.json` have `440`/`-r--r-----` file permissions (user & group read only). This improves security by limiting which users and processes that have access to these files. If you are getting `permission denied` errors when handling your keystores, consider changing which user/group owns the file (with `chown`) or, if need be, change the file permissions with `chmod`.
+
 #### Option 1. Download binary executable file
 
 ##### Step 1. Installation

--- a/eth2deposit/credentials.py
+++ b/eth2deposit/credentials.py
@@ -153,6 +153,8 @@ class CredentialList:
         filefolder = os.path.join(folder, 'deposit_data-%i.json' % time.time())
         with open(filefolder, 'w') as f:
             json.dump(deposit_data, f, default=lambda x: x.hex())
+        if os.name == 'posix':
+            os.chmod(filefolder, int('440', 8))  # Read for owner & group
         return filefolder
 
     def verify_keystores(self, keystore_filefolders: List[str], password: str) -> bool:

--- a/eth2deposit/key_handling/keystore.py
+++ b/eth2deposit/key_handling/keystore.py
@@ -5,6 +5,7 @@ from dataclasses import (
     field as dataclass_field
 )
 import json
+import os
 from py_ecc.bls import G2ProofOfPossession as bls
 from secrets import randbits
 from typing import Any, Dict, Union
@@ -90,12 +91,14 @@ class Keystore(BytesDataclass):
     def kdf(self, **kwargs: Any) -> bytes:
         return scrypt(**kwargs) if 'scrypt' in self.crypto.kdf.function else PBKDF2(**kwargs)
 
-    def save(self, file: str) -> None:
+    def save(self, filefolder: str) -> None:
         """
         Save self as a JSON keystore.
         """
-        with open(file, 'w') as f:
+        with open(filefolder, 'w') as f:
             f.write(self.as_json())
+        if os.name == 'posix':
+            os.chmod(filefolder, int('440', 8))  # Read for owner & group
 
     @classmethod
     def from_json(cls, json_dict: Dict[Any, Any]) -> 'Keystore':

--- a/tests/test_cli/helpers.py
+++ b/tests/test_cli/helpers.py
@@ -19,3 +19,7 @@ def clean_key_folder(my_folder_path: str) -> None:
 def get_uuid(key_file: str) -> str:
     keystore = Keystore.from_file(key_file)
     return keystore.uuid
+
+
+def get_permissions(path: str, file_name: str) -> str:
+    return oct(os.stat(os.path.join(path, file_name)).st_mode & 0o777)

--- a/tests/test_cli/test_existing_menmonic.py
+++ b/tests/test_cli/test_existing_menmonic.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 
 from eth2deposit.deposit import cli
 from eth2deposit.utils.constants import DEFAULT_VALIDATOR_KEYS_FOLDER_NAME
-from.helpers import clean_key_folder, get_uuid
+from.helpers import clean_key_folder, get_permissions, get_uuid
 
 
 def test_existing_mnemonic() -> None:
@@ -38,6 +38,10 @@ def test_existing_mnemonic() -> None:
     ]
     assert len(set(all_uuid)) == 5
 
+    # Verify file permissions
+    if os.name == 'posix':
+        for file_name in key_files:
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
     # Clean up
     clean_key_folder(my_folder_path)
 
@@ -84,6 +88,11 @@ async def test_script() -> None:
     # Check files
     validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
     _, _, key_files = next(os.walk(validator_keys_folder_path))
+
+    # Verify file permissions
+    if os.name == 'posix':
+        for file_name in key_files:
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
 
     # Clean up
     clean_key_folder(my_folder_path)

--- a/tests/test_cli/test_new_mnemonic.py
+++ b/tests/test_cli/test_new_mnemonic.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 from eth2deposit.cli import new_mnemonic
 from eth2deposit.deposit import cli
 from eth2deposit.utils.constants import DEFAULT_VALIDATOR_KEYS_FOLDER_NAME
-from .helpers import clean_key_folder, get_uuid
+from .helpers import clean_key_folder, get_permissions, get_uuid
 
 
 def test_new_mnemonic(monkeypatch) -> None:
@@ -39,6 +39,11 @@ def test_new_mnemonic(monkeypatch) -> None:
         if key_file.startswith('keystore')
     ]
     assert len(set(all_uuid)) == 1
+
+    # Verify file permissions
+    if os.name == 'posix':
+        for file_name in key_files:
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
 
     # Clean up
     clean_key_folder(my_folder_path)
@@ -102,6 +107,11 @@ async def test_script() -> None:
         if key_file.startswith('keystore')
     ]
     assert len(set(all_uuid)) == 5
+
+    # Verify file permissions
+    if os.name == 'posix':
+        for file_name in key_files:
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
 
     # Clean up
     clean_key_folder(my_folder_path)

--- a/tests/test_cli/test_regeneration.py
+++ b/tests/test_cli/test_regeneration.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 from eth2deposit.cli import new_mnemonic
 from eth2deposit.deposit import cli
 from eth2deposit.utils.constants import DEFAULT_VALIDATOR_KEYS_FOLDER_NAME
-from .helpers import clean_key_folder, get_uuid
+from .helpers import clean_key_folder, get_permissions, get_uuid
 
 
 def test_regeneration(monkeypatch) -> None:
@@ -47,6 +47,11 @@ def test_regeneration(monkeypatch) -> None:
                 for key_file in part_1_key_files]
     assert len(set(all_uuid)) == 2
 
+    # Verify file permissions
+    if os.name == 'posix':
+        for file_name in part_1_key_files:
+            assert get_permissions(validator_keys_folder_path_1, file_name) == '0o440'
+
     # Part 2: existing-mnemonic
     runner = CliRunner()
     # Create index 1 and 2
@@ -77,6 +82,11 @@ def test_regeneration(monkeypatch) -> None:
         keystore_2_0 = json.load(f)
     assert keystore_1_1['pubkey'] == keystore_2_0['pubkey']
     assert keystore_1_1['path'] == keystore_2_0['path']
+
+    # Verify file permissions
+    if os.name == 'posix':
+        for file_name in part_2_key_files:
+            assert get_permissions(validator_keys_folder_path_2, file_name) == '0o440'
 
     # Clean up
     clean_key_folder(folder_path_1)


### PR DESCRIPTION
File permissions seem different between users and are usually globally readable. This PR address this by `chmod`ing the keystores and `deposit_data.json` to `440` owner and group read only.