### PR TITLE
Test compiled executable binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,8 +124,16 @@ jobs:
             pyenv global 3.7.5;
             pyinstaller --distpath ./${BUILD_FILE_NAME} ./build_configs/linux/build.spec;
       - run:
+          name: Test executable binaries
+          command: |
+            export PYTHONHASHSEED=42
+            export CIRCLE_SHORT_SHA1=$(eval echo $CIRCLE_SHA1 | cut -c -7)
+            export BUILD_FILE_NAME=eth2deposit-cli-${CIRCLE_SHORT_SHA1}-linux-amd64;
+            python test_binary_script.py ./${BUILD_FILE_NAME};
+      - run:
           name: Compress the file
           command: |
+            export PYTHONHASHSEED=42
             export CIRCLE_SHORT_SHA1=$(eval echo $CIRCLE_SHA1 | cut -c -7)
             export BUILD_FILE_NAME=eth2deposit-cli-${CIRCLE_SHORT_SHA1}-linux-amd64;
             tar -zcvf ${BUILD_FILE_NAME}.tar.gz ./${BUILD_FILE_NAME};
@@ -153,8 +161,16 @@ jobs:
             $BUILD_FILE_NAME_PATH = ".\" + $BUILD_FILE_NAME
             pyinstaller --distpath $BUILD_FILE_NAME_PATH .\build_configs\windows\build.spec
       - run:
+          name: Test executable binaries
+          command: |
+            $PYTHONHASHSEED = 42
+            $CIRCLE_SHORT_SHA1 = $env:CIRCLE_SHA1.substring(0,7)
+            $BUILD_FILE_NAME = "eth2deposit-cli-" + $CIRCLE_SHORT_SHA1 + "-windows-amd64"
+            python test_binary_script.py .\${BUILD_FILE_NAME}
+      - run:
           name: Compress the file
           command: |
+            $PYTHONHASHSEED = 42
             $CIRCLE_SHORT_SHA1 = $env:CIRCLE_SHA1.substring(0,7)
             $BUILD_FILE_NAME = "eth2deposit-cli-" + $CIRCLE_SHORT_SHA1 + "-windows-amd64"
             $BUILD_FILE_NAME_PATH = ".\" + $BUILD_FILE_NAME
@@ -186,8 +202,16 @@ jobs:
             mkdir ${BUILD_FILE_NAME};
             pyinstaller --distpath ./${BUILD_FILE_NAME} ./build_configs/macos/build.spec;
       - run:
+          name: Test executable binaries
+          command: |
+            export PYTHONHASHSEED=42
+            export CIRCLE_SHORT_SHA1=$(eval echo $CIRCLE_SHA1 | cut -c -7)
+            export BUILD_FILE_NAME=eth2deposit-cli-${CIRCLE_SHORT_SHA1}-darwin-amd64;
+            python3 test_binary_script.py ./${BUILD_FILE_NAME};
+      - run:
           name: Compress the file
           command: |
+            export PYTHONHASHSEED=42
             export CIRCLE_SHORT_SHA1=$(eval echo $CIRCLE_SHA1 | cut -c -7)
             export BUILD_FILE_NAME=eth2deposit-cli-${CIRCLE_SHORT_SHA1}-darwin-amd64;
             tar -zcvf ${BUILD_FILE_NAME}.tar.gz ./${BUILD_FILE_NAME};

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ venv_build_test: venv_build
 	${VENV_NAME}/bin/python -m pip install -r requirements_test.txt
 
 venv_test: venv_build_test
-	$(VENV_ACTIVATE) && python -m pytest .
+	$(VENV_ACTIVATE) && python -m pytest ./tests
 
 venv_lint: venv_build_test
 	$(VENV_ACTIVATE) && flake8 --config=flake8.ini ./eth2deposit ./tests && mypy --config-file mypy.ini -p eth2deposit

--- a/test_binary_script.py
+++ b/test_binary_script.py
@@ -1,0 +1,73 @@
+import asyncio
+import os
+import sys
+
+
+# For not importing eth2deposit here
+DEFAULT_VALIDATOR_KEYS_FOLDER_NAME = 'validator_keys'
+
+
+async def main(argv):
+    binary_file_path = argv[1]
+    my_folder_path = os.path.join(os.getcwd(), 'TESTING_TEMP_FOLDER')
+    if not os.path.exists(my_folder_path):
+        os.mkdir(my_folder_path)
+
+    if os.name == 'nt':  # Windows
+        run_script_cmd = ".\\" + binary_file_path + '\deposit.exe'
+    else:  # Mac or Linux
+        run_script_cmd = './' + binary_file_path + '/deposit'
+
+    cmd_args = [
+        run_script_cmd + ' new-mnemonic',
+        '--num_validators', '1',
+        '--mnemonic_language', 'english',
+        '--chain', 'mainnet',
+        '--keystore_password', 'MyPassword',
+        '--folder', my_folder_path,
+    ]
+    proc = await asyncio.create_subprocess_shell(
+        ' '.join(cmd_args),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    seed_phrase = ''
+    parsing = False
+    async for out in proc.stdout:
+        output = out.decode('utf-8').rstrip()
+        if output.startswith("This is your seed phrase."):
+            parsing = True
+        elif output.startswith("Please type your mnemonic"):
+            parsing = False
+        elif parsing:
+            seed_phrase += output
+            if len(seed_phrase) > 0:
+                encoded_phrase = seed_phrase.encode()
+                proc.stdin.write(encoded_phrase)
+                proc.stdin.write(b'\n')
+        print(output)
+
+    async for out in proc.stderr:
+        output = out.decode('utf-8').rstrip()
+        print(f'[stderr] {output}')
+
+    assert len(seed_phrase) > 0
+
+    # Check files
+    validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
+    _, _, key_files = next(os.walk(validator_keys_folder_path))
+
+    # Clean up
+    for key_file_name in key_files:
+        os.remove(os.path.join(validator_keys_folder_path, key_file_name))
+    os.rmdir(validator_keys_folder_path)
+    os.rmdir(my_folder_path)
+
+
+if os.name == 'nt':  # Windows
+    loop = asyncio.ProactorEventLoop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main(sys.argv))
+else:
+    asyncio.run(main(sys.argv))


### PR DESCRIPTION
Fix #137

- Add `test_binary_script.py` to test the binary files Basically copied from `test_deposit_script.py` but plus some edits.
- Run `test_binary_script.py` after compiling.