### PR TITLE
Added clarification on number of validators prompt

### DIFF
--- a/eth2deposit/cli/generate_keys.py
+++ b/eth2deposit/cli/generate_keys.py
@@ -80,7 +80,7 @@ def generate_keys_arguments_decorator(function: Callable[..., Any]) -> Callable[
     decorators = [
         click.option(
             '--num_validators',
-            prompt='Please choose how many validators you wish to run',
+            prompt='Please choose how many new validators you wish to run',
             help='The number of validators keys you want to generate (you can always generate more later)',
             required=True,
             type=click.IntRange(0, 2**32 - 1),


### PR DESCRIPTION
Hey there - thanks for all the work on this tool, it's great.  While testing it out recently, I noticed that the prompt for the number of keys to generate is unclear (mostly when running with an existing mnemonic).  It currently reads, for both new and existing mnemonics, as:
"Please choose how many validators you wish to run"

This makes sense for creating from a new mnemonic, but when creating from an existing mnemonic it is unclear if that prompt is asking you for the total validators you'd like to run (including those you already have keys for) or just the number of new ones.  After testing, it is the latter - you are supposed to specify the number of new validators you'd like to generate keys for.

This PR simply changes the above from "validators" to "new validators" which I feel makes it more clear. I understand the same prompt is use for both new and existing flows, and I think will both benefit from the clarity.

Thanks in advance for taking a look!