### PR TITLE
Fix binaries import for intl languages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,11 @@ jobs:
             export PYTHONHASHSEED=42
             export CIRCLE_SHORT_SHA1=$(eval echo $CIRCLE_SHA1 | cut -c -7)
             export BUILD_FILE_NAME=eth2deposit-cli-${CIRCLE_SHORT_SHA1}-linux-amd64;
+            export TEST_FOLDER_NAME=TMP_TEST_FOLDER
+            mkdir ${TEST_FOLDER_NAME}
+            cp ${BUILD_FILE_NAME} ${TEST_FOLDER_NAME}
+            cp test_binary_script.py ${TEST_FOLDER_NAME}
+            cd ${TEST_FOLDER_NAME}
             python test_binary_script.py ./${BUILD_FILE_NAME};
       - run:
           name: Compress the file
@@ -166,6 +171,11 @@ jobs:
             $PYTHONHASHSEED = 42
             $CIRCLE_SHORT_SHA1 = $env:CIRCLE_SHA1.substring(0,7)
             $BUILD_FILE_NAME = "eth2deposit-cli-" + $CIRCLE_SHORT_SHA1 + "-windows-amd64"
+            $TEST_FOLDER_NAME = "TMP_TEST_FOLDER"
+            mkdir ${TEST_FOLDER_NAME}
+            copy ${BUILD_FILE_NAME} ${TEST_FOLDER_NAME}
+            copy test_binary_script.py ${TEST_FOLDER_NAME}
+            cd ${TEST_FOLDER_NAME}
             python test_binary_script.py .\${BUILD_FILE_NAME}
       - run:
           name: Compress the file
@@ -207,6 +217,11 @@ jobs:
             export PYTHONHASHSEED=42
             export CIRCLE_SHORT_SHA1=$(eval echo $CIRCLE_SHA1 | cut -c -7)
             export BUILD_FILE_NAME=eth2deposit-cli-${CIRCLE_SHORT_SHA1}-darwin-amd64;
+            export TEST_FOLDER_NAME=TMP_TEST_FOLDER
+            mkdir ${TEST_FOLDER_NAME}
+            cp ${BUILD_FILE_NAME} ${TEST_FOLDER_NAME}
+            cp test_binary_script.py ${TEST_FOLDER_NAME}
+            cd ${TEST_FOLDER_NAME}
             python3 test_binary_script.py ./${BUILD_FILE_NAME};
       - run:
           name: Compress the file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
             $BUILD_FILE_NAME = "eth2deposit-cli-" + $CIRCLE_SHORT_SHA1 + "-windows-amd64"
             $TEST_FOLDER_NAME = "TMP_TEST_FOLDER"
             mkdir ${TEST_FOLDER_NAME}
-            copy ${BUILD_FILE_NAME} ${TEST_FOLDER_NAME}
+            Copy-item ${BUILD_FILE_NAME} -destination ${TEST_FOLDER_NAME} -recurse
             copy test_binary_script.py ${TEST_FOLDER_NAME}
             cd ${TEST_FOLDER_NAME}
             python test_binary_script.py ${BUILD_FILE_NAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
             export BUILD_FILE_NAME=eth2deposit-cli-${CIRCLE_SHORT_SHA1}-linux-amd64;
             export TEST_FOLDER_NAME=TMP_TEST_FOLDER
             mkdir ${TEST_FOLDER_NAME}
-            cp ${BUILD_FILE_NAME} ${TEST_FOLDER_NAME}
+            cp -r ${BUILD_FILE_NAME} ${TEST_FOLDER_NAME}
             cp test_binary_script.py ${TEST_FOLDER_NAME}
             cd ${TEST_FOLDER_NAME}
             python test_binary_script.py ./${BUILD_FILE_NAME};
@@ -176,7 +176,7 @@ jobs:
             copy ${BUILD_FILE_NAME} ${TEST_FOLDER_NAME}
             copy test_binary_script.py ${TEST_FOLDER_NAME}
             cd ${TEST_FOLDER_NAME}
-            python test_binary_script.py .\${BUILD_FILE_NAME}
+            python test_binary_script.py ${BUILD_FILE_NAME}
       - run:
           name: Compress the file
           command: |
@@ -219,7 +219,7 @@ jobs:
             export BUILD_FILE_NAME=eth2deposit-cli-${CIRCLE_SHORT_SHA1}-darwin-amd64;
             export TEST_FOLDER_NAME=TMP_TEST_FOLDER
             mkdir ${TEST_FOLDER_NAME}
-            cp ${BUILD_FILE_NAME} ${TEST_FOLDER_NAME}
+            cp -r ${BUILD_FILE_NAME} ${TEST_FOLDER_NAME}
             cp test_binary_script.py ${TEST_FOLDER_NAME}
             cd ${TEST_FOLDER_NAME}
             python3 test_binary_script.py ./${BUILD_FILE_NAME};

--- a/build_configs/macos/build.spec
+++ b/build_configs/macos/build.spec
@@ -7,7 +7,7 @@ a = Analysis(['../../eth2deposit/deposit.py'],
              binaries=None,
              datas=[
                  ('../../eth2deposit/key_handling/key_derivation/word_lists/*.txt', './eth2deposit/key_handling/key_derivation/word_lists/'),
-                 ('../../eth2deposit/intl', './eth2deposit/intl',)
+                 ('../../eth2deposit/intl', './eth2deposit/intl'),
              ],
              hiddenimports=[],
              hookspath=[],

--- a/eth2deposit/key_handling/key_derivation/mnemonic.py
+++ b/eth2deposit/key_handling/key_derivation/mnemonic.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from unicodedata import normalize
 from secrets import randbits
 from typing import (
@@ -14,19 +13,9 @@ from eth2deposit.utils.crypto import (
     SHA256,
     PBKDF2,
 )
-
-
-def _resource_path(relative_path: str) -> str:
-    """
-    Get the absolute path to a resource in a manner friendly to PyInstaller.
-    PyInstaller creates a temp folder and stores path in _MEIPASS which this function swaps
-    into a resource path so it is avaible both when building binaries and running natively.
-    """
-    try:
-        base_path = sys._MEIPASS  # type: ignore
-    except Exception:
-        base_path = os.path.abspath(".")
-    return os.path.join(base_path, relative_path)
+from eth2deposit.utils.file_handling import (
+    resource_path,
+)
 
 
 def _get_word_list(language: str, path: str) -> Sequence[str]:
@@ -35,7 +24,7 @@ def _get_word_list(language: str, path: str) -> Sequence[str]:
 
     Ref: https://github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md
     """
-    path = _resource_path(path)
+    path = resource_path(path)
     dirty_list = open(os.path.join(path, '%s.txt' % language), encoding='utf-8').readlines()
     return [word.replace('\n', '') for word in dirty_list]
 

--- a/eth2deposit/utils/file_handling.py
+++ b/eth2deposit/utils/file_handling.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+
+def resource_path(relative_path: str) -> str:
+    """
+    Get the absolute path to a resource in a manner friendly to PyInstaller.
+    PyInstaller creates a temp folder and stores path in _MEIPASS which this function swaps
+    into a resource path so it is available both when building binaries and running natively.
+    """
+    try:
+        base_path = sys._MEIPASS  # type: ignore
+    except Exception:
+        base_path = os.path.abspath(".")
+    print(base_path, relative_path)
+    return os.path.join(base_path, relative_path)

--- a/eth2deposit/utils/file_handling.py
+++ b/eth2deposit/utils/file_handling.py
@@ -12,5 +12,4 @@ def resource_path(relative_path: str) -> str:
         base_path = sys._MEIPASS  # type: ignore
     except Exception:
         base_path = os.path.abspath(".")
-    print(base_path, relative_path)
     return os.path.join(base_path, relative_path)

--- a/eth2deposit/utils/intl.py
+++ b/eth2deposit/utils/intl.py
@@ -55,8 +55,7 @@ def load_text(params: List[str], file_path: str='', func: str='', lang: str='') 
     # Determine path to json text
     file_path_list = os.path.normpath(file_path).split(os.path.sep)
     rel_path_list = file_path_list[file_path_list.index('eth2deposit') + 1:]
-    json_path = os.path.join(INTL_CONTENT_PATH, lang, *rel_path_list)
-    json_path = resource_path(json_path)
+    json_path = resource_path(os.path.join(INTL_CONTENT_PATH, lang, *rel_path_list))
 
     try:
         # browse json until text is found

--- a/eth2deposit/utils/intl.py
+++ b/eth2deposit/utils/intl.py
@@ -16,6 +16,9 @@ from eth2deposit.utils import config
 from eth2deposit.utils.constants import (
     INTL_CONTENT_PATH,
 )
+from eth2deposit.utils.file_handling import (
+    resource_path,
+)
 from eth2deposit.exceptions import ValidationError
 
 
@@ -53,6 +56,7 @@ def load_text(params: List[str], file_path: str='', func: str='', lang: str='') 
     file_path_list = os.path.normpath(file_path).split(os.path.sep)
     rel_path_list = file_path_list[file_path_list.index('eth2deposit') + 1:]
     json_path = os.path.join(INTL_CONTENT_PATH, lang, *rel_path_list)
+    json_path = resource_path(json_path)
 
     try:
         # browse json until text is found


### PR DESCRIPTION
The binaries in `dev` do not contain the json language files from `\intl\`, this is not detected in the current tests either as they have access to the `.\intl\` files via the python path from which the binaries are run.

## Changes
* `intl` files are imported via a check for `sys._MEIPASS` which means they are now loaded for both the binaries and natively running the python `deposit.py`
* CI tests for binaries are now conduced from a sub-folder so the python path doesn't contain the root directory which contained the `intl` files