### PR TITLE
Additional withdrawal key warning as a NO_WITHDRAWAL_KEY_HERE.txt file

### DIFF
--- a/eth2deposit/cli/generate_keys.py
+++ b/eth2deposit/cli/generate_keys.py
@@ -146,6 +146,7 @@ def generate_keys(ctx: click.Context, validator_start_index: int,
     )
     keystore_filefolders = credentials.export_keystores(password=keystore_password, folder=folder)
     deposits_file = credentials.export_deposit_data_json(folder=folder)
+    credentials.export_withdrawal_warning(folder=folder)
     if not credentials.verify_keystores(keystore_filefolders=keystore_filefolders, password=keystore_password):
         raise ValidationError("Failed to verify the keystores.")
     if not verify_deposit_data_json(deposits_file, credentials.credentials):

--- a/eth2deposit/credentials.py
+++ b/eth2deposit/credentials.py
@@ -203,6 +203,14 @@ class CredentialList:
             os.chmod(filefolder, int('440', 8))  # Read for owner & group
         return filefolder
 
+    def export_withdrawal_warning(self, folder: str) -> str:
+        filefolder = os.path.join(folder, 'NO_WITHDRAWAL_KEY_HERE.txt')
+        with open(filefolder, 'w') as f:
+            f.write('Write down and store your seed phrase safely, it is the ONLY way to retrieve your deposit.')
+        if os.name == 'posix':
+            os.chmod(filefolder, int('440', 8))  # Read for owner & group
+        return filefolder
+
     def verify_keystores(self, keystore_filefolders: List[str], password: str) -> bool:
         with click.progressbar(zip(self.credentials, keystore_filefolders), label='Verifying your keystores:\t',
                                length=len(self.credentials), show_percent=False, show_pos=True) as items:

--- a/tests/test_cli/test_new_mnemonic.py
+++ b/tests/test_cli/test_new_mnemonic.py
@@ -48,6 +48,8 @@ def test_new_mnemonic_bls_withdrawal(monkeypatch) -> None:
         for file_name in key_files:
             assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
 
+    # Verify withdrawal warning file
+    assert os.path.exists(os.path.join(validator_keys_folder_path, 'NO_WITHDRAWAL_KEY_HERE.txt'))
     # Clean up
     clean_key_folder(my_folder_path)
 


### PR DESCRIPTION
Trying to make the tool even more foolproof by placing a NO_WITHDRAWAL_KEY_HERE.txt file into the "validator_keys" folder.
Hope this will minimize chances that only the "validator_keys" folder will be saved by a user but not a mnemonic leading to a lost deposit. 
There is a keystore-* file in this folder that may create an illusion that preserving just the "validator_keys" folder may be enough to withdraw the deposit.