### PR TITLE
Add ARM builds to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,39 @@ jobs:
             sha256sum ${BUILD_FILE_NAME}.tar.gz | head -c 64 > /tmp/artifacts/${BUILD_FILE_NAME}.sha256
       - store_artifacts:
           path: /tmp/artifacts
+  build-linux-arm:
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.medium
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: Install building requirements on Linux
+          command: |
+            env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5;
+            pyenv global 3.7.5;
+            pip install -r ./build_configs/linux/requirements.txt;
+      - run:
+          name: Build with build.spec
+          command: |
+            export PYTHONHASHSEED=42
+            export CIRCLE_SHORT_SHA1=$(eval echo $CIRCLE_SHA1 | cut -c -7)
+            export BUILD_FILE_NAME=eth2deposit-cli-${CIRCLE_SHORT_SHA1}-linux-aarch64;
+            mkdir ${BUILD_FILE_NAME};
+            pyenv global 3.7.5;
+            pyinstaller --distpath ./${BUILD_FILE_NAME} ./build_configs/linux/build.spec;
+      - run:
+          name: Compress the file
+          command: |
+            export CIRCLE_SHORT_SHA1=$(eval echo $CIRCLE_SHA1 | cut -c -7)
+            export BUILD_FILE_NAME=eth2deposit-cli-${CIRCLE_SHORT_SHA1}-linux-aarch64;
+            tar -zcvf ${BUILD_FILE_NAME}.tar.gz ./${BUILD_FILE_NAME};
+            mkdir /tmp/artifacts;
+            cp ${BUILD_FILE_NAME}.tar.gz /tmp/artifacts;
+            sha256sum ${BUILD_FILE_NAME}.tar.gz | head -c 64 > /tmp/artifacts/${BUILD_FILE_NAME}.sha256
+      - store_artifacts:
+          path: /tmp/artifacts
   build-windows:
     executor:
       name: win/default
@@ -216,6 +249,7 @@ workflows:
   build_linux:
     jobs:
       - build-linux
+      - build-linux-arm
   build_windows:
     jobs:
         - build-windows

--- a/build_configs/linux/requirements.txt
+++ b/build_configs/linux/requirements.txt
@@ -2,8 +2,8 @@
 -r ../../requirements.txt
 
 # Build tools for binary distribution
-PyInstaller==3.6 \
-    --hash=sha256:3730fa80d088f8bb7084d32480eb87cbb4ddb64123363763cf8f2a1378c1c4b7
+PyInstaller==4.7 \
+    --hash=sha256:2c7f4810dc5272ec1b388a7f1ff6b56d38653c1b0c9ac2d9dd54fa06b590e372
 setuptools==49.2.0 \
     --hash=sha256:272c7f48f5cddc5af5901f4265274c421c7eede5c8bc454ac2903d3f8fc365e9 \
     --hash=sha256:afe9e81fee0270d3f60d52608549cc8ec4c46dada8c95640c1a00160f577acf2
@@ -45,3 +45,17 @@ altgraph==0.17 \
 macholib==1.14 \
     --hash=sha256:0c436bc847e7b1d9bda0560351bf76d7caf930fb585a828d13608839ef42c432 \
     --hash=sha256:c500f02867515e6c60a27875b408920d18332ddf96b4035ef03beddd782d4281
+
+# Dependencies for the above
+pyinstaller-hooks-contrib==2021.4 \
+    --hash=sha256:60a57e4057fa2183bbaa81f10401a27eb7dd701ef8a11b287bb6345b571f94e7 \
+    --hash=sha256:775b52200b39e12c95cc24f809eb050a97110fee819d178ebfde214f0f51e5f4
+importlib-metadata==4.9.0 \
+    --hash=sha256:ee50794eccb0ec340adbc838344ebb9a6ff2bcba78f752d31fc716497e2149d6 \
+    --hash=sha256:e8b45564028bc25f8c99f546616112a6df5de6655893d7eb74c9a99680dc9751
+typing-extensions==4.0.1 \
+    --hash=sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e \
+    --hash=sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b
+zipp==3.6.0 \
+    --hash=sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832 \
+    --hash=sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc \


### PR DESCRIPTION
ARM builds are useful for those wanting to generate keys on an offline ARM machine, most accessible of which is a raspberry pi. Currently, to use eth2.0-deposit-cli on an ARM machine, the user must connect to the internet to install dependencies. This defeats the purpose of an offline machine. This PR would close #82 .

The first commit creates `build-linux-arm`, a copy of `build-linux` which uses an [ARM CI environment](https://circleci.com/docs/2.0/arm-resources/), freely supported by Circle CI. However, the current specified version of PyInstaller (3.6) required for building the binary fails to compile due to warnings and `-Werror`: [Circle CI link for the first commit](https://app.circleci.com/pipelines/github/Raekye/eth2.0-deposit-cli/3/workflows/ee00908f-79ef-46dc-919e-55c78297f0ad/jobs/24).

The second commit updates PyInstaller to the latest version ([4.7](https://pypi.org/project/pyinstaller/#files)). Just doing this also fails, as transitive dependencies of PyInstaller are not pinned to a specific version, which is required by the hashes. Just as in the project's root `requirements.txt`, the specific versions of transitive dependencies are specified at the bottom of `build_configs/linux/requirements.txt`. Since these dependencies were only specified with `>=`, I opted to use the latest versions of the underspecified packages (links provided for convenient checking of the hashes):

- [pyinstaller-hooks-contrib 2021.4](https://pypi.org/project/pyinstaller-hooks-contrib/#files)
- [importlib-metadata 4.9.0](https://pypi.org/project/importlib-metadata/#files)
- [typing-extensions 4.0.1](https://pypi.org/project/typing-extensions/#files)
- [zipp 3.6.0](https://pypi.org/project/zipp/#files)

The `build-linux` CI job continues to pass with the updated dependencies: [Circle CI link for `build-linux` and `build-linux-arm`](https://app.circleci.com/pipelines/github/Raekye/eth2.0-deposit-cli/5/workflows/a4f54869-687c-42ac-8efd-d122caec839a). I tested the ARM artifacts produced on an emulated qemu ARM vm and it seems to work fine. I will test on a raspberry pi later today