### PR TITLE
Fix Xcode version in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
           path: /tmp/artifacts
   build-macos:
     macos:
-      xcode: 11.3.0
+      xcode: 12.4.0
     working_directory: ~/repo
     steps:
       - run: xcodebuild -version


### PR DESCRIPTION
CircleCI dropped support for Xcode 11.3. As such we needed to bump it, v12.4 seems reasonable, it still supports MacOS 10.15.5, and >=v12.2 is needed for M1 support ala #224.