### PR TITLE
Bumps CLI_VERSION to 2.0.0

### DIFF
--- a/staking_deposit/settings.py
+++ b/staking_deposit/settings.py
@@ -1,7 +1,7 @@
 from typing import Dict, NamedTuple
 
 
-DEPOSIT_CLI_VERSION = '1.2.0'
+DEPOSIT_CLI_VERSION = '2.0.0'
 
 
 class BaseChainSetting(NamedTuple):


### PR DESCRIPTION
Bumps the CLI_VERSION to 2.0.0 (as discussed in https://github.com/ethereum/eth2.0-deposit-cli/pull/240#discussion_r798127952)